### PR TITLE
Custom About Layout

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,16 @@ let package = Package(
 			name: "MoreWindows",
 			targets: ["MoreWindows"]
 		),
+
+		.library(
+			name: "MoreWindows_About",
+			targets: ["MoreWindows_About"]
+		),
+
+		.library(
+			name: "MoreWindows_Launcher",
+			targets: ["MoreWindows_Launcher"]
+		),
 	],
 	targets: [
 		.target(
@@ -22,7 +32,7 @@ let package = Package(
 				"MoreWindows_Launcher",
 			]
 		),
-		
+
 		.target(
 			name: "MoreWindows_About",
 			dependencies: [

--- a/Sources/MoreWindows_About/Data/AboutWindowLayout.swift
+++ b/Sources/MoreWindows_About/Data/AboutWindowLayout.swift
@@ -1,0 +1,11 @@
+/// The layout style of an ``About`` window.
+public enum AboutWindowLayout: UInt8 {
+	/// Provide custom content for the about window.
+	///
+	/// Using this layout will ignore any ``AboutWindowOptions``.
+	case custom
+	/// Display the about window as a vertical list, with app information at the top.
+	case verticalList
+	/// Display the about window in a horizontal layout, with app information on the left side and additional information on the right side.
+	case horizontal
+}

--- a/Sources/MoreWindows_About/Data/AboutWindowLayout.swift
+++ b/Sources/MoreWindows_About/Data/AboutWindowLayout.swift
@@ -4,8 +4,6 @@ public enum AboutWindowLayout: UInt8 {
 	///
 	/// Using this layout will ignore any ``AboutWindowOptions``.
 	case custom
-	/// Display the about window as a vertical list, with app information at the top.
-	case verticalList
-	/// Display the about window in a horizontal layout, with app information on the left side and additional information on the right side.
-	case horizontal
+	/// Display the about window as a vertical stack, with app information at the top, copyright at the bottom, and custom content in the middle.
+	case vertical
 }

--- a/Sources/MoreWindows_About/Environment/AboutWindowLayoutKey.swift
+++ b/Sources/MoreWindows_About/Environment/AboutWindowLayoutKey.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 private struct AboutWindowLayoutKey: EnvironmentKey {
-	static let defaultValue: AboutWindowLayout = .verticalList
+	static let defaultValue: AboutWindowLayout = .vertical
 }
 
 extension EnvironmentValues {

--- a/Sources/MoreWindows_About/Environment/AboutWindowLayoutKey.swift
+++ b/Sources/MoreWindows_About/Environment/AboutWindowLayoutKey.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+private struct AboutWindowLayoutKey: EnvironmentKey {
+	static let defaultValue: AboutWindowLayout = .verticalList
+}
+
+extension EnvironmentValues {
+	fileprivate(set) var aboutWindowLayout: AboutWindowLayout {
+		get { self[AboutWindowLayoutKey.self] }
+		set { self[AboutWindowLayoutKey.self] = newValue }
+	}
+}
+
+public extension Scene {
+	/// Set the layout style of an ``About`` window.
+	/// - Parameter layout: The layout to set in the environment.
+	func aboutWindowLayout(_ layout: AboutWindowLayout) -> some Scene {
+		environment(\.aboutWindowLayout, layout)
+	}
+}

--- a/Sources/MoreWindows_About/Views/AppInfoSection.swift
+++ b/Sources/MoreWindows_About/Views/AppInfoSection.swift
@@ -1,17 +1,17 @@
 import _MoreWindowsCommon
 import SwiftUI
 
-struct AppInfoSection: View {
+public struct AppInfoSection: View {
 	@Environment(\.aboutWindowOptions) private var aboutWindowOptions
 
-	var body: some View {
-		VStack {
-			AppIconView(size: 128)
+	public init() { }
 
-			Text(AppInformation.appName)
-				.font(.title.bold())
+	public var body: some View {
+		AppIconView(size: 128)
 
-			AppVersionView()
-		}
+		Text(AppInformation.appName)
+			.font(.title.bold())
+
+		AppVersionView()
 	}
 }

--- a/Sources/MoreWindows_About/Views/ContentView.swift
+++ b/Sources/MoreWindows_About/Views/ContentView.swift
@@ -7,5 +7,9 @@ struct ContentView<Content: View>: View {
 	let content: () -> Content
 
 	var body: some View {
+		switch aboutWindowLayout {
+			case .custom: content()
+			case .vertical: VerticalContentView(content: content)
+		}
 	}
 }

--- a/Sources/MoreWindows_About/Views/ContentView.swift
+++ b/Sources/MoreWindows_About/Views/ContentView.swift
@@ -2,29 +2,10 @@ import _MoreWindowsCommon
 import SwiftUI
 
 struct ContentView<Content: View>: View {
-	@Environment(\.aboutWindowOptions) private var aboutWindowOptions
+	@Environment(\.aboutWindowLayout) private var aboutWindowLayout
 
 	let content: () -> Content
 
 	var body: some View {
-		VStack(spacing: 32) {
-			Divided {
-				if aboutWindowOptions.contains(.showDefaultInformation) {
-					AppInfoSection()
-				}
-
-				content()
-
-				if aboutWindowOptions.contains(.showDefaultCopyright), let copyright = AppInformation.copyright {
-					Text(copyright)
-						.font(.caption)
-				}
-			}
-		}
-		.fixedSize()
-		.offset(y: 13) // half title bar height
-		.padding(.horizontal, 13) // equal padding for horizontal axis
-		.padding(24) // breathing room
-		.ignoresSafeArea(.container)
 	}
 }

--- a/Sources/MoreWindows_About/Views/VerticalContentView.swift
+++ b/Sources/MoreWindows_About/Views/VerticalContentView.swift
@@ -1,7 +1,7 @@
 import _MoreWindowsCommon
 import SwiftUI
 
-struct VerticalListContentView<Content: View>: View {
+struct VerticalContentView<Content: View>: View {
 	@Environment(\.aboutWindowOptions) private var aboutWindowOptions
 
 	let content: () -> Content
@@ -10,7 +10,9 @@ struct VerticalListContentView<Content: View>: View {
 		VStack(spacing: 32) {
 			Divided {
 				if aboutWindowOptions.contains(.showDefaultInformation) {
-					AppInfoSection()
+					VStack {
+						AppInfoSection()
+					}
 				}
 
 				content()

--- a/Sources/MoreWindows_About/Views/VerticalListContentView.swift
+++ b/Sources/MoreWindows_About/Views/VerticalListContentView.swift
@@ -1,0 +1,30 @@
+import _MoreWindowsCommon
+import SwiftUI
+
+struct VerticalListContentView<Content: View>: View {
+	@Environment(\.aboutWindowOptions) private var aboutWindowOptions
+
+	let content: () -> Content
+
+	var body: some View {
+		VStack(spacing: 32) {
+			Divided {
+				if aboutWindowOptions.contains(.showDefaultInformation) {
+					AppInfoSection()
+				}
+
+				content()
+
+				if aboutWindowOptions.contains(.showDefaultCopyright), let copyright = AppInformation.copyright {
+					Text(copyright)
+						.font(.caption)
+				}
+			}
+		}
+		.fixedSize()
+		.offset(y: 13) // half title bar height
+		.padding(.horizontal, 13) // equal padding for horizontal axis
+		.padding(24) // breathing room
+		.ignoresSafeArea(.container)
+	}
+}


### PR DESCRIPTION
**Added support custom layouts for the About window.**
This can be accomplished by using `.aboutWindowLayout(_:)` to set an environment variable.  By default, this is set to `.vertical`.
Note that using the `.custom` value will cause the view to ignore environment variable set with `.aboutWindowOptions(_:)`.

**Exposed `AppInfoView`**
This contains the app icon, name, and version, as seen in the `.vertical` About window layout.  It can also be used with custom About window layouts.